### PR TITLE
Installing jq package

### DIFF
--- a/salt/th/jenkins/init.sls
+++ b/salt/th/jenkins/init.sls
@@ -20,6 +20,9 @@ oldjava:
     - require_in:
       - service: jenkins
 
+jq:
+  pkg.installed
+
 sbt:
   archive.extracted:
     - name: /var/lib/jenkins/.bin


### PR DESCRIPTION
Heroku's maintains a JSON API version of https://status.heroku.com/ at https://status.heroku.com/api/v3/current-status. An easy way to process results is:

```
$ curl https://status.heroku.com/api/v3/current-status | jq .status.Production
"green"
```

We could also rewrite this as:
```
$ [ "$(curl https://status.heroku.com/api/v3/current-status | tee /tmp/heroku.json | jq -M '.status.Production')" = '"green"' ] || (jq '.issues[]' < /tmp/heroku.json; exit 1)
```
to print some details about what's going on directly into the jenkins log (not sure how much data the `issues` object will contain, this could be too much data, but it seems like a good start.